### PR TITLE
fix worker pool implementation

### DIFF
--- a/main.go
+++ b/main.go
@@ -23,7 +23,7 @@ func main() {
 	listener := NewListener(in_addr)
 	listener.Start()
 
-	decoder := NewDecoder(listener.RawPackets, 1000)
+	decoder := NewDecoder(listener.RawPackets, *cpu)
 	decoder.Start()
 
 	publisher := NewPublisher(out_addr, decoder.Decoded, *gzip)


### PR DESCRIPTION
There are should be only num of CPU amount of workers, that are using same input work
channel.

Also fix format in timing output, because of on multiple cores there
will be more than 1s CPU time per 1s real time available.
