### PR TITLE
Updated protobuf import url

### DIFF
--- a/decoder/request.go
+++ b/decoder/request.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"bytes"
-	"code.google.com/p/goprotobuf/proto"
+	"github.com/golang/protobuf/proto"
 	"fmt"
 	"strconv"
 )


### PR DESCRIPTION
Fixes an issue I've just met that protobuf's google code repo is dead:
```
wicked@w:~/.../github.com/olegfedoseev/pinba-server/decoder (master)$ go get
package code.google.com/p/goprotobuf/proto: unable to detect version control system for code.google.com/ path
```